### PR TITLE
remove Wire.begin from library

### DIFF
--- a/BH1750.cpp
+++ b/BH1750.cpp
@@ -3,8 +3,9 @@
   This is a library for the BH1750FVI Digital Light Sensor
   breakout board.
 
-  The board uses I2C for communication. 2 pins are required to
-  interface to the device.
+  The BH1750 board uses I2C for communication. Two pins are required to
+  interface to the device. Configuring the I2C bus is expected to be done
+  in user code. The BH1750 library doesn't do this automatically.
 
   Written by Christopher Laws, March, 2013.
 
@@ -58,30 +59,12 @@ BH1750::BH1750(byte addr) {
 
 
 /**
- * Begin I2C and configure sensor
- * @param SDA Date SCL Clock mode Measurment mode
- */
-#if defined(ARDUINO_ARCH_ESP8266)
-void BH1750::begin(uint8_t SDA, uint8_t SCL, uint8_t mode) {
-
-  // allow config of pins
-  Wire.begin(SDA, SCL);
-
-  // Configure sensor in specified mode
-  configure(mode);
-
-}
-#endif
-
-
-/**
- * Begin I2C and configure sensor
+ * Configure sensor
  * @param mode Measurment mode
  */
 void BH1750::begin(uint8_t mode) {
 
-  // Initialize I2C
-  Wire.begin();
+  // I2C is expected to be initialized outside this library
 
   // Configure sensor in specified mode
   configure(mode);
@@ -94,7 +77,6 @@ void BH1750::begin(uint8_t mode) {
  * @param mode Measurment mode
  */
 void BH1750::configure(uint8_t mode) {
-
 
   // Check measurment mode is valid
   switch (mode) {

--- a/BH1750.h
+++ b/BH1750.h
@@ -3,8 +3,9 @@
   This is a library for the BH1750FVI Digital Light Sensor
   breakout board.
 
-  The board uses I2C for communication. 2 pins are required to
-  interface to the device.
+  The BH1750 board uses I2C for communication. Two pins are required to
+  interface to the device. Configuring the I2C bus is expected to be done
+  in user code. The BH1750 library doesn't do this automatically.
 
   Datasheet: http://rohmfs.rohm.com/en/products/databook/datasheet/ic/sensor/light/bh1750fvi-e.pdf
 
@@ -60,10 +61,6 @@ class BH1750 {
 
   public:
     BH1750 (byte addr = 0x23);
-    #if defined(ARDUINO_ARCH_ESP8266)
-    /* ==== On esp8266 it is possible to define I2C pins ==== */
-    void begin (uint8_t SDA, uint8_t SCL, uint8_t mode = BH1750_CONTINUOUS_HIGH_RES_MODE);
-    #endif
     void begin (uint8_t mode = BH1750_CONTINUOUS_HIGH_RES_MODE);
     void configure (uint8_t mode);
     uint16_t readLightLevel(void);

--- a/README.md
+++ b/README.md
@@ -2,13 +2,18 @@
 
 [![Build Status](https://travis-ci.org/claws/BH1750.svg?branch=master)](https://travis-ci.org/claws/BH1750)<br>
 
-An Arduino library for digital light sensor breakout boards containing the BH1750FVI IC.
+An Arduino library for digital light sensor breakout boards containing the
+BH1750FVI IC.
 
-The board uses I2C for communication, and two pins are required to interface to the device.
+The BH1750 board uses I2C for communication, and two pins are required to
+interface to the device. Configuring the I2C bus is best done in user code
+(not library code) so that it can be done once and can more easily make use
+of various options for different platforms.
 
-Datasheet can be obtained [here](http://rohmfs.rohm.com/en/products/databook/datasheet/ic/sensor/light/bh1750fvi-e.pdf)
 
-The BH1750 had six different measurment modes. They are divided in two groups;
+## Overview
+
+The BH1750 has six different measurment modes. They are divided in two groups;
 continuous and one-time measurments. In continuous mode, the sensor continuously
 measures lightness value. In one-time mode, sensor makes only one measurment, and
 then goes into Power Down mode after this.
@@ -38,6 +43,44 @@ ADD pin is used to set sensor I2C address. If it has voltage greater or equal to
 0x5C. In other case (if ADD voltage less than 0.7 * VCC) the sensor address will
 be 0x23 (by default).
 
+The datasheet for the BH1750 can be obtained [here](http://rohmfs.rohm.com/en/products/databook/datasheet/ic/sensor/light/bh1750fvi-e.pdf)
+
+
+## Example
+
+``` c++
+#include <Wire.h>
+#include <BH1750.h>
+
+BH1750 lightMeter;
+
+void setup(){
+
+  Serial.begin(9600);
+
+  // Initialize the I2C bus (BH1750 library doesn't do this automatically)
+  // On esp8266 devices you can select SCL and SDA pins using Wire.begin(D4, D3);
+  Wire.begin();
+
+  lightMeter.begin();
+  Serial.println(F("BH1750 Test"));
+
+}
+
+void loop() {
+
+  uint16_t lux = lightMeter.readLightLevel();
+  Serial.print("Light: ");
+  Serial.print(lux);
+  Serial.println(" lx");
+  delay(1000);
+
+}
+```
+
+There are more examples in the examples directory. One shows a simple use while
+the other shows a more advanced use case.
+
 
 ## Installation
 
@@ -52,9 +95,3 @@ Click "Clone or download" -> "Download ZIP" button.
     to `BH1750`. Restart IDE.
 
 Additional info, about library installation process - https://www.arduino.cc/en/Guide/Libraries
-
-
-## Examples
-
-There are two examples in the examples directory. One shows a simple use while
-the other shows a more advanced use case.

--- a/examples/BH1750advanced/BH1750advanced.ino
+++ b/examples/BH1750advanced/BH1750advanced.ino
@@ -38,9 +38,13 @@ void setup(){
 
   Serial.begin(9600);
 
+  // Initialize the I2C bus (BH1750 library doesn't do this automatically)
+  Wire.begin();
+  // On esp8266 you can select SCL and SDA pins using Wire.begin(D4, D3);
+
   /*
 
-    BH1750 had six different measurment modes. They are divided in two groups -
+    BH1750 has six different measurment modes. They are divided in two groups -
     continuous and one-time measurments. In continuous mode, sensor continuously
     measures lightness value. And in one-time mode, sensor makes only one
     measurment, and going to Power Down mode after this.

--- a/examples/BH1750test/BH1750test.ino
+++ b/examples/BH1750test/BH1750test.ino
@@ -28,8 +28,13 @@ BH1750 lightMeter;
 void setup(){
 
   Serial.begin(9600);
+
+  // Initialize the I2C bus (BH1750 library doesn't do this automatically)
+  Wire.begin();
+  // On esp8266 you can select SCL and SDA pins using Wire.begin(D4, D3);
+
   lightMeter.begin();
-  //lightMeter.begin(begin(D4, D3)); // use this line on a esp8266 to modify pins
+
   Serial.println(F("BH1750 Test"));
 
 }


### PR DESCRIPTION
This change set addresses #16 by removing library calls to ``Wire.begin``. The library now expects the I2C bus to be initialised outside the library. This minimises issues encountered when multiple libraries are used that each call ``Wire.begin``. Examples and the README have been updated to follow this expectation.