### PR TITLE
One time measurement wait

### DIFF
--- a/BH1750.cpp
+++ b/BH1750.cpp
@@ -118,7 +118,7 @@ void BH1750::configure(uint8_t mode) {
  * Read light level from sensor
  * @return Light level in lux (0 ~ 65535)
  */
-uint16_t BH1750::readLightLevel(void) {
+uint16_t BH1750::readLightLevel(bool saveWait) {
 
   // Measurment result will be stored here
   uint16_t level;
@@ -132,14 +132,12 @@ uint16_t BH1750::readLightLevel(void) {
       __wire_write((uint8_t)BH1750_MODE);
       if (BH1750_MODE == BH1750_ONE_TIME_LOW_RES_MODE)
       {
-        //_delay_ms(16); //typical value
-        _delay_ms(24); //max value
+        saveWait ? _delay_ms(24) : _delay_ms(16); //max value : typical value
       }
       else
       {
-        //_delay_ms(120); //typical value
-        _delay_ms(180); //max value
-      }
+        saveWait ? _delay_ms(180) :_delay_ms(120); //max value : typical value
+      } 
       break;
   }
 

--- a/BH1750.cpp
+++ b/BH1750.cpp
@@ -130,6 +130,19 @@ uint16_t BH1750::readLightLevel(void) {
     case BH1750_ONE_TIME_HIGH_RES_MODE_2:
     case BH1750_ONE_TIME_LOW_RES_MODE:
       __wire_write((uint8_t)BH1750_MODE);
+			if (BH1750_MODE >= 0x20) {
+				configure(BH1750_MODE);
+				if (BH1750_MODE == BH1750_ONE_TIME_LOW_RES_MODE)
+				{
+				  //_delay_ms(16); //typical value
+				  _delay_ms(24); //max value
+				}
+				else
+				{
+				  //_delay_ms(120); //typical value
+				  _delay_ms(180); //max value
+				}
+			}
       break;
   }
 

--- a/BH1750.cpp
+++ b/BH1750.cpp
@@ -130,19 +130,16 @@ uint16_t BH1750::readLightLevel(void) {
     case BH1750_ONE_TIME_HIGH_RES_MODE_2:
     case BH1750_ONE_TIME_LOW_RES_MODE:
       __wire_write((uint8_t)BH1750_MODE);
-			if (BH1750_MODE >= 0x20) {
-				configure(BH1750_MODE);
-				if (BH1750_MODE == BH1750_ONE_TIME_LOW_RES_MODE)
-				{
-				  //_delay_ms(16); //typical value
-				  _delay_ms(24); //max value
-				}
-				else
-				{
-				  //_delay_ms(120); //typical value
-				  _delay_ms(180); //max value
-				}
-			}
+      if (BH1750_MODE == BH1750_ONE_TIME_LOW_RES_MODE)
+      {
+        //_delay_ms(16); //typical value
+        _delay_ms(24); //max value
+      }
+      else
+      {
+        //_delay_ms(120); //typical value
+        _delay_ms(180); //max value
+      }
       break;
   }
 

--- a/BH1750.h
+++ b/BH1750.h
@@ -63,7 +63,7 @@ class BH1750 {
     BH1750 (byte addr = 0x23);
     void begin (uint8_t mode = BH1750_CONTINUOUS_HIGH_RES_MODE);
     void configure (uint8_t mode);
-    uint16_t readLightLevel(void);
+    uint16_t readLightLevel(bool saveWait = true);
 
   private:
     int BH1750_I2CADDR;


### PR DESCRIPTION
as mentioned already in #17 
if you use the one time mode, the sensor needs time to measure. it differs between the low and high mode. The worst case value is preselected.