### PR TITLE
add one time mode measure delay

### DIFF
--- a/BH1750.h
+++ b/BH1750.h
@@ -63,7 +63,7 @@ class BH1750 {
     BH1750 (byte addr = 0x23);
     void begin (uint8_t mode = BH1750_CONTINUOUS_HIGH_RES_MODE);
     void configure (uint8_t mode);
-    uint16_t readLightLevel(void);
+    uint16_t readLightLevel(bool maxWait = false);
 
   private:
     int BH1750_I2CADDR;

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Each mode, has three different precisions:
   - High Resolution Mode 2 - (0.5 lx precision, 120ms measurment time)
 
 By default, this library uses Continuous High Resolution Mode, but you can set
-any other mode by definepassing the mode argument to BH1750.begin().
+any other mode by passing the mode argument to BH1750.begin().
 
-Remember, if you use One-Time mode, your sensor will go to Power Down mode
-each time, when it completes measurment and you've read it.
+Remember, if you use One-Time mode, your sensor will go into Power Down mode
+when it completes the measurment and you've read it.
 
 Typical Connection:
 
@@ -43,8 +43,7 @@ ADD pin is used to set sensor I2C address. If it has voltage greater or equal to
 0x5C. In other case (if ADD voltage less than 0.7 * VCC) the sensor address will
 be 0x23 (by default).
 
-The datasheet for the BH1750 can be obtained [here](http://rohmfs.rohm.com/en/products/databook/datasheet/ic/sensor/light/bh1750fvi-e.pdf)
-
+The datasheet for the BH1750 can be obtained [here](http://www.elechouse.com/elechouse/images/product/Digital%20light%20Sensor/bh1750fvi-e.pdf)
 
 ## Example
 

--- a/examples/BH1750advanced/BH1750advanced.ino
+++ b/examples/BH1750advanced/BH1750advanced.ino
@@ -2,7 +2,7 @@
 
   Advanced BH1750 library usage example
 
-  This example had some comments about advanced usage features.
+  This example has some comments about advanced usage features.
 
   Connection:
 
@@ -46,8 +46,8 @@ void setup(){
 
     BH1750 has six different measurment modes. They are divided in two groups -
     continuous and one-time measurments. In continuous mode, sensor continuously
-    measures lightness value. And in one-time mode, sensor makes only one
-    measurment, and going to Power Down mode after this.
+    measures lightness value. In one-time mode the sensor makes only one
+    measurment and then goes into Power Down mode.
 
     Each mode, has three different precisions:
 
@@ -55,11 +55,12 @@ void setup(){
       - High Resolution Mode - (1 lx precision, 120ms measurment time)
       - High Resolution Mode 2 - (0.5 lx precision, 120ms measurment time)
 
-    By default, library use Continuous High Resolution Mode, but you can set
-    any other mode, by define it to BH1750.begin() or BH1750.configure() functions.
+    By default, the library uses Continuous High Resolution Mode, but you can
+    set any other mode, by passing it to BH1750.begin() or BH1750.configure()
+    functions.
 
-    [!] Remember, if you use One-Time mode, your sensor will go to Power Down mode
-    each time, when it completes measurment and you've read it.
+    [!] Remember, if you use One-Time mode, your sensor will go to Power Down
+    mode each time, when it completes measurment and you've read it.
 
     Full mode list:
 

--- a/examples/BH1750test/BH1750test.ino
+++ b/examples/BH1750test/BH1750test.ino
@@ -2,8 +2,8 @@
 
   Example of BH1750 library usage.
 
-  This example initalises the BH1750 object using the default
-  high resolution mode and then makes a light level reading every second.
+  This example initalises the BH1750 object using the default high resolution
+  continuous mode and then makes a light level reading every second.
 
   Connection:
 


### PR DESCRIPTION
This change resolves #21 by applying the suggested update (with some extra comments and minor changes such as variable naming (e.g. saveWait -> maxWait)). The logic is slightly changed to use the typical wait time by default. User may pass maxWait=True to instead wait the maximum time before reading the measurement in one-time modes.

Also:
- Updates data sheet reference to a working link.
- Minor grammar and typos updates to README and examples.