### PR TITLE
Fix issues observed in continuous mode

### DIFF
--- a/BH1750.cpp
+++ b/BH1750.cpp
@@ -53,13 +53,14 @@
 BH1750::BH1750(byte addr) {
 
   BH1750_I2CADDR = addr;
+  BH1750_CONFIGURED = false;
 
 }
 
 
 /**
  * Configure sensor
- * @param mode Measurment mode
+ * @param mode Measurement mode
  */
 bool BH1750::begin(uint8_t mode) {
 
@@ -72,15 +73,17 @@ bool BH1750::begin(uint8_t mode) {
 
 
 /**
- * Configure BH1750 with specified working mode
- * @param mode Measurment mode
+ * Configure BH1750 with specified mode
+ * @param mode Measurement mode
  */
 bool BH1750::configure(uint8_t mode) {
-  
+
+  BH1750_CONFIGURED = false;
+
   // default transmission result to a value out of normal range
   byte ack = 5;
-  
-  // Check measurment mode is valid
+
+  // Check measurement mode is valid
   switch (mode) {
 
     case BH1750_CONTINUOUS_HIGH_RES_MODE:
@@ -103,7 +106,7 @@ bool BH1750::configure(uint8_t mode) {
 
       // Invalid measurement mode
       #ifdef BH1750_DEBUG
-      Serial.println(F("BH1750: Invalid measurment mode"));
+      Serial.println(F("[BH1750] ERROR: Invalid measurement mode"));
       #endif
 
       break;
@@ -112,30 +115,30 @@ bool BH1750::configure(uint8_t mode) {
 
   // Check result code
   switch (ack) {
-    case 0: 
-      BH1750_MODE = mode; 
-      return true;
-    case 1: //too long for transmit buffer
+    case 0:
+      BH1750_MODE = mode;
+      BH1750_CONFIGURED = true;
+    case 1: // too long for transmit buffer
       #ifdef BH1750_DEBUG
-      Serial.println(F("too long for transmit buffer"));
+      Serial.println(F("[BH1750] ERROR: too long for transmit buffer"));
       #endif
-    case 2: //received NACK on transmit of address
+    case 2: // received NACK on transmit of address
       #ifdef BH1750_DEBUG
-      Serial.println(F("received NACK on transmit of address"));
+      Serial.println(F("[BH1750] ERROR: received NACK on transmit of address"));
       #endif
-    case 3: //received NACK on transmit of data
+    case 3: // received NACK on transmit of data
       #ifdef BH1750_DEBUG
-      Serial.println(F("received NACK on transmit of data"));
+      Serial.println(F("[BH1750] ERROR: received NACK on transmit of data"));
       #endif
-    case 4: //other error
+    case 4: // other error
       #ifdef BH1750_DEBUG
-      Serial.println(F("other error"));
+      Serial.println(F("[BH1750] ERROR: other error"));
       #endif
-    default: 
+    default:
       break;
   }
 
-  return false;
+  return BH1750_CONFIGURED;
 
 }
 
@@ -146,42 +149,46 @@ bool BH1750::configure(uint8_t mode) {
  */
 uint16_t BH1750::readLightLevel(bool maxWait) {
 
-  // Measurment result will be stored here
+  if (!BH1750_CONFIGURED) {
+    Serial.println(F("[BH1750] Device is not configured!"));
+    return 0;
+  }
+
+  // Measurement result will be stored here
   uint16_t level;
 
-  // One-Time modes need to be re-applied after power-up. They have a maximum
-  // measurement time and a typical measurement time. The maxWait argument
-  // determines which measurement wait time is used when a one-time mode is
-  // being used. The typical (shorter) measurement time is used by default and
-  // if maxWait is set to True then the maximum measurement time will be used.
-  // See data sheet pages 2, 5 and 7 for more details.
+  // Send mode to sensor
+  Wire.beginTransmission(BH1750_I2CADDR);
+  __wire_write((uint8_t)BH1750_MODE);
+  Wire.endTransmission();
+
+  // Wait for measurement to be taken.
+  // Measurements have a maximum measurement time and a typical measurement
+  // time. The maxWait argument determines which measurement wait time is
+  // used when a one-time mode is being used. The typical (shorter)
+  // measurement time is used by default and if maxWait is set to True then
+  // the maximum measurement time will be used. See data sheet pages 2, 5
+  // and 7 for more details.
   switch (BH1750_MODE) {
 
+    case BH1750_CONTINUOUS_LOW_RES_MODE:
+    case BH1750_ONE_TIME_LOW_RES_MODE:
+      maxWait ? _delay_ms(24) : _delay_ms(16);
+      break;
+
+    case BH1750_CONTINUOUS_HIGH_RES_MODE:
+    case BH1750_CONTINUOUS_HIGH_RES_MODE_2:
     case BH1750_ONE_TIME_HIGH_RES_MODE:
     case BH1750_ONE_TIME_HIGH_RES_MODE_2:
-    case BH1750_ONE_TIME_LOW_RES_MODE:
-
-      // Send mode to sensor
-      Wire.beginTransmission(BH1750_I2CADDR);
-      __wire_write((uint8_t)BH1750_MODE);
-      Wire.endTransmission();
-
-      // wait for measurement time
-      if (BH1750_MODE == BH1750_ONE_TIME_LOW_RES_MODE) {
-        maxWait ? _delay_ms(24) : _delay_ms(16);
-      }
-      else {
-        maxWait ? _delay_ms(180) :_delay_ms(120);
-      }
+      maxWait ? _delay_ms(180) :_delay_ms(120);
       break;
 
   }
 
-  // Read two bytes from sensor
+  // Read two bytes from the sensor, which are low and high parts of the sensor
+  // value
   Wire.requestFrom(BH1750_I2CADDR, 2);
-
   if (Wire.available() == 2) {
-  // Read two bytes, which are low and high parts of sensor value
     level = __wire_read();
     level <<= 8;
     level |= __wire_read();

--- a/BH1750.h
+++ b/BH1750.h
@@ -68,6 +68,7 @@ class BH1750 {
   private:
     int BH1750_I2CADDR;
     uint8_t BH1750_MODE;
+    bool BH1750_CONFIGURED;
 
 };
 

--- a/README.md
+++ b/README.md
@@ -17,23 +17,23 @@ A common module containing the BH1750 component is the GY-30 shown below.
 
 ## Overview
 
-The BH1750 has six different measurment modes which are divided in two groups;
-continuous and one-time measurments. In continuous mode the sensor
+The BH1750 has six different measurement modes which are divided in two groups;
+continuous and one-time measurements. In continuous mode the sensor
 continuously measures lightness value. In one-time mode, the sensor makes only
-one measurment and then goes into Power Down mode.
+one measurement and then goes into Power Down mode.
 
 Each mode has three different precisions:
 
-  - Low Resolution Mode - (4 lx precision, 16ms measurment time)
-  - High Resolution Mode - (1 lx precision, 120ms measurment time)
-  - High Resolution Mode 2 - (0.5 lx precision, 120ms measurment time)
+  - Low Resolution Mode - (4 lx precision, 16ms measurement time)
+  - High Resolution Mode - (1 lx precision, 120ms measurement time)
+  - High Resolution Mode 2 - (0.5 lx precision, 120ms measurement time)
 
 By default, this library uses Continuous High Resolution Mode, but you can
 change this to a different mode by passing the mode argument to
 BH1750.begin().
 
 When the One-Time mode is used your sensor will go into Power Down mode when
-it completes the measurment and you've read it. When the sensor is powered up
+it completes the measurement and you've read it. When the sensor is powered up
 again it returns to the default mode which means it needs to be reconfigured
 back into One-Time mode. This library has been implemented to automatically
 reconfigure the sensor when you next attempt a measurement so you should not

--- a/examples/BH1750advanced/BH1750advanced.ino
+++ b/examples/BH1750advanced/BH1750advanced.ino
@@ -44,23 +44,23 @@ void setup(){
 
   /*
 
-    BH1750 has six different measurment modes. They are divided in two groups -
-    continuous and one-time measurments. In continuous mode, sensor continuously
+    BH1750 has six different measurement modes. They are divided in two groups;
+    continuous and one-time measurements. In continuous mode, sensor continuously
     measures lightness value. In one-time mode the sensor makes only one
-    measurment and then goes into Power Down mode.
+    measurement and then goes into Power Down mode.
 
     Each mode, has three different precisions:
 
-      - Low Resolution Mode - (4 lx precision, 16ms measurment time)
-      - High Resolution Mode - (1 lx precision, 120ms measurment time)
-      - High Resolution Mode 2 - (0.5 lx precision, 120ms measurment time)
+      - Low Resolution Mode - (4 lx precision, 16ms measurement time)
+      - High Resolution Mode - (1 lx precision, 120ms measurement time)
+      - High Resolution Mode 2 - (0.5 lx precision, 120ms measurement time)
 
     By default, the library uses Continuous High Resolution Mode, but you can
     set any other mode, by passing it to BH1750.begin() or BH1750.configure()
     functions.
 
     [!] Remember, if you use One-Time mode, your sensor will go to Power Down
-    mode each time, when it completes measurment and you've read it.
+    mode each time, when it completes a measurement and you've read it.
 
     Full mode list:
 
@@ -74,8 +74,13 @@ void setup(){
 
   */
 
-  lightMeter.begin(BH1750_CONTINUOUS_HIGH_RES_MODE);
-  Serial.println(F("BH1750 Test"));
+  // begin returns a boolean that can be used to detect setup problems.
+  if (lightMeter.begin(BH1750_CONTINUOUS_HIGH_RES_MODE)) {
+    Serial.println(F("BH1750 Advanced begin"));
+  }
+  else {
+    Serial.println(F("Error initialising BH1750"));
+  }
 
 }
 

--- a/examples/BH1750onetime/BH1750onetime.ino
+++ b/examples/BH1750onetime/BH1750onetime.ino
@@ -2,7 +2,7 @@
 
   Example of BH1750 library usage.
 
-  This example initalises the BH1750 object using the high resolution
+  This example initialises the BH1750 object using the high resolution
   one-time mode and then makes a light level reading every second.
 
   The BH1750 component starts up in default mode when it next powers up.

--- a/examples/BH1750test/BH1750test.ino
+++ b/examples/BH1750test/BH1750test.ino
@@ -35,7 +35,7 @@ void setup(){
 
   lightMeter.begin();
 
-  Serial.println(F("BH1750 Test"));
+  Serial.println(F("BH1750 Test begin"));
 
 }
 


### PR DESCRIPTION
Continuous mode examples were not working properly. Now both Continuous and One-Time mode examples work as expected. Values are observed without problems being reported (i.e. first measurement appears to work fine). This change should resolve the problem noted in #28.

This change fixes #27, #28.

Other changes:
- Adds a boolean variable to track whether the device has been configured. This can be used to abort readings if necessary.
- Fixes for various spelling errors.
- Update the advanced example with a demonstration of using the return value from ``begin`` to detect setup problems.
- Updates consistency of some error messages printed out when debug is enabled.
  