### PR TITLE
fix regression

### DIFF
--- a/BH1750.h
+++ b/BH1750.h
@@ -30,45 +30,41 @@
 // No active state
 #define BH1750_POWER_DOWN 0x00
 
-// Wating for measurment command
+// Wating for measurement command
 #define BH1750_POWER_ON 0x01
 
 // Reset data register value - not accepted in POWER_DOWN mode
 #define BH1750_RESET 0x07
 
-// Start measurement at 1lx resolution. Measurement time is approx 120ms.
-#define BH1750_CONTINUOUS_HIGH_RES_MODE  0x10
-
-// Start measurement at 0.5lx resolution. Measurement time is approx 120ms.
-#define BH1750_CONTINUOUS_HIGH_RES_MODE_2  0x11
-
-// Start measurement at 4lx resolution. Measurement time is approx 16ms.
-#define BH1750_CONTINUOUS_LOW_RES_MODE  0x13
-
-// Start measurement at 1lx resolution. Measurement time is approx 120ms.
-// Device is automatically set to Power Down after measurement.
-#define BH1750_ONE_TIME_HIGH_RES_MODE  0x20
-
-// Start measurement at 0.5lx resolution. Measurement time is approx 120ms.
-// Device is automatically set to Power Down after measurement.
-#define BH1750_ONE_TIME_HIGH_RES_MODE_2  0x21
-
-// Start measurement at 1lx resolution. Measurement time is approx 120ms.
-// Device is automatically set to Power Down after measurement.
-#define BH1750_ONE_TIME_LOW_RES_MODE  0x23
-
 class BH1750 {
 
   public:
-    BH1750 (byte addr = 0x23);
-    bool begin (uint8_t mode = BH1750_CONTINUOUS_HIGH_RES_MODE);
-    bool configure (uint8_t mode);
+
+    enum Mode
+    {
+      UNCONFIGURED = 0,
+      // Measurement at 1lx resolution. Measurement time is approx 120ms.
+      CONTINUOUS_HIGH_RES_MODE  = 0x10,
+      // Measurement at 0.5lx resolution. Measurement time is approx 120ms.
+      CONTINUOUS_HIGH_RES_MODE_2 = 0x11,
+      // Measurement at 4lx resolution. Measurement time is approx 16ms.
+      CONTINUOUS_LOW_RES_MODE = 0x13,
+      // Measurement at 1lx resolution. Measurement time is approx 120ms.
+      ONE_TIME_HIGH_RES_MODE = 0x20,
+      // Measurement at 0.5lx resolution. Measurement time is approx 120ms.
+      ONE_TIME_HIGH_RES_MODE_2 = 0x21,
+      // Measurement at 1lx resolution. Measurement time is approx 120ms.
+      ONE_TIME_LOW_RES_MODE = 0x23
+    };
+
+    BH1750(byte addr = 0x23);
+    bool begin(Mode mode = CONTINUOUS_HIGH_RES_MODE);
+    bool configure(Mode mode);
     uint16_t readLightLevel(bool maxWait = false);
 
   private:
     int BH1750_I2CADDR;
-    uint8_t BH1750_MODE;
-    bool BH1750_CONFIGURED;
+    Mode BH1750_MODE = UNCONFIGURED;
 
 };
 

--- a/examples/BH1750advanced/BH1750advanced.ino
+++ b/examples/BH1750advanced/BH1750advanced.ino
@@ -75,7 +75,7 @@ void setup(){
   */
 
   // begin returns a boolean that can be used to detect setup problems.
-  if (lightMeter.begin(BH1750_CONTINUOUS_HIGH_RES_MODE)) {
+  if (lightMeter.begin(BH1750::CONTINUOUS_HIGH_RES_MODE)) {
     Serial.println(F("BH1750 Advanced begin"));
   }
   else {

--- a/examples/BH1750onetime/BH1750onetime.ino
+++ b/examples/BH1750onetime/BH1750onetime.ino
@@ -24,7 +24,7 @@ void setup(){
   Wire.begin();
   // On esp8266 you can select SCL and SDA pins using Wire.begin(D4, D3);
 
-  lightMeter.begin(BH1750_ONE_TIME_HIGH_RES_MODE);
+  lightMeter.begin(BH1750::ONE_TIME_HIGH_RES_MODE);
 
   Serial.println(F("BH1750 One-Time Test"));
 


### PR DESCRIPTION
Fix regression that caused continuous mode to wait (similar to one time mode) before taking a measurement.

Convert mode to an enumeration as suggested in comment in #31.

Remove the BH1750_CONFIGURED boolean in preference to simply using the mode to detect if the software thinks the device has been configured.

All examples seem to work properly.
