### PR TITLE
updates

### DIFF
--- a/BH1750.cpp
+++ b/BH1750.cpp
@@ -100,12 +100,8 @@ bool BH1750::configure(Mode mode) {
       break;
 
     default:
-
       // Invalid measurement mode
-      #ifdef BH1750_DEBUG
-      Serial.println(F("[BH1750] ERROR: Invalid BH1750 mode"));
-      #endif
-
+      Serial.println(F("[BH1750] ERROR: Invalid mode"));
       break;
 
   }
@@ -116,22 +112,15 @@ bool BH1750::configure(Mode mode) {
       BH1750_MODE = mode;
       return true;
     case 1: // too long for transmit buffer
-      #ifdef BH1750_DEBUG
       Serial.println(F("[BH1750] ERROR: too long for transmit buffer"));
-      #endif
     case 2: // received NACK on transmit of address
-      #ifdef BH1750_DEBUG
       Serial.println(F("[BH1750] ERROR: received NACK on transmit of address"));
-      #endif
     case 3: // received NACK on transmit of data
-      #ifdef BH1750_DEBUG
       Serial.println(F("[BH1750] ERROR: received NACK on transmit of data"));
-      #endif
     case 4: // other error
-      #ifdef BH1750_DEBUG
       Serial.println(F("[BH1750] ERROR: other error"));
-      #endif
     default:
+      Serial.println(F("[BH1750] ERROR: undefined error"));
       break;
   }
 

--- a/examples/BH1750advanced/BH1750advanced.ino
+++ b/examples/BH1750advanced/BH1750advanced.ino
@@ -28,7 +28,7 @@
     - 0x23 (most common) (if ADD pin had < 0.7VCC voltage)
     - 0x5C (if ADD pin had > 0.7VCC voltage)
 
-  Library use 0x23 address as default, but you can define any other address.
+  Library uses 0x23 address as default, but you can define any other address.
   If you had troubles with default value - try to change it to 0x5C.
 
 */

--- a/examples/BH1750test/BH1750test.ino
+++ b/examples/BH1750test/BH1750test.ino
@@ -2,7 +2,7 @@
 
   Example of BH1750 library usage.
 
-  This example initalises the BH1750 object using the default high resolution
+  This example initialises the BH1750 object using the default high resolution
   continuous mode and then makes a light level reading every second.
 
   Connection:
@@ -24,6 +24,7 @@
 #include <BH1750.h>
 
 BH1750 lightMeter;
+
 
 void setup(){
 


### PR DESCRIPTION
Currently the library only reports error message when debug is enabled. To enable debug mode uncommenting a line in the header file is required. This is inconvenient for a typical user. Instead, error messages should always be shown as they helpful when fault finding.

Fix up some typos errors in examples.