### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,15 +6,15 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-BH1750 KEYWORD1
+BH1750	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin          KEYWORD2
-configure      KEYWORD2
-readLightLevel KEYWORD2
+begin	KEYWORD2
+configure	KEYWORD2
+readLightLevel	KEYWORD2
 
 
 #######################################
@@ -25,9 +25,9 @@ readLightLevel KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-BH1750_CONTINUOUS_HIGH_RES_MODE    LITERAL1
-BH1750_CONTINUOUS_HIGH_RES_MODE_2  LITERAL1
-BH1750_CONTINUOUS_LOW_RES_MODE     LITERAL1
-BH1750_ONE_TIME_HIGH_RES_MODE      LITERAL1
-BH1750_ONE_TIME_HIGH_RES_MODE_2    LITERAL1
-BH1750_ONE_TIME_LOW_RES_MODE       LITERAL1
+BH1750_CONTINUOUS_HIGH_RES_MODE	LITERAL1
+BH1750_CONTINUOUS_HIGH_RES_MODE_2	LITERAL1
+BH1750_CONTINUOUS_LOW_RES_MODE	LITERAL1
+BH1750_ONE_TIME_HIGH_RES_MODE	LITERAL1
+BH1750_ONE_TIME_HIGH_RES_MODE_2	LITERAL1
+BH1750_ONE_TIME_LOW_RES_MODE	LITERAL1


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords