### PR TITLE
Better error handling if not two bytes are available for read.

### DIFF
--- a/BH1750.cpp
+++ b/BH1750.cpp
@@ -180,6 +180,8 @@ uint16_t BH1750::readLightLevel(bool maxWait) {
     level = __wire_read();
     level <<= 8;
     level |= __wire_read();
+  } else {
+	  Wire.reset();
   }
 
   // Print raw value if debug enabled


### PR DESCRIPTION
Do not tear down I2C bus forever if not 2 bytes are available for read.

This is sometimes the case, and after such an unsuccessful read the I2C bus
was held down forever and stopped working (for all other components on the bus,
too!)
