### PR TITLE
Fix for incorrect bit shift when setting MTReg high bits value.

### DIFF
--- a/BH1750.cpp
+++ b/BH1750.cpp
@@ -153,7 +153,7 @@ bool BH1750::setMTreg(byte MTreg) {
   __wire_write((0b01000 << 3) | (MTreg >> 5));
   ack = Wire.endTransmission();
   Wire.beginTransmission(BH1750_I2CADDR);
-  __wire_write((0b011 << 5 )  | (MTreg & 0b111));
+  __wire_write((0b011 << 5 )  | (MTreg & 0b11111));
   ack = ack | Wire.endTransmission();
   Wire.beginTransmission(BH1750_I2CADDR);
   __wire_write(BH1750_MODE);


### PR DESCRIPTION
The change addresses the issue raised in #57 which identifies a bug in the bit shift applied to the high value of the MTReg. The value was incorrectly being ANDed with only 3 ones when it should be 5 ones.