### PR TITLE
Add support for setting TwoWire instance 

### DIFF
--- a/BH1750.cpp
+++ b/BH1750.cpp
@@ -30,17 +30,17 @@
 
 // Legacy Wire.write() function fix
 #if (ARDUINO >= 100)
-  #define __wire_write(d) Wire.write(d)
+  #define __wire_write(d) I2C->write(d)
 #else
-  #define __wire_write(d) Wire.send(d)
+  #define __wire_write(d) I2C->send(d)
 #endif
 
 
 // Legacy Wire.read() function fix
 #if (ARDUINO >= 100)
-  #define __wire_read() Wire.read()
+  #define __wire_read() I2C->read()
 #else
-  #define __wire_read() Wire.receive()
+  #define __wire_read() I2C->receive()
 #endif
 
 
@@ -53,17 +53,27 @@
 BH1750::BH1750(byte addr) {
 
   BH1750_I2CADDR = addr;
-
+  // Allows user to change TwoWire instance
+  I2C = &Wire;
 }
 
 
 /**
  * Configure sensor
  * @param mode Measurement mode
+ * @param addr Address of the sensor
+ * @param i2c TwoWire instance connected to I2C bus
  */
-bool BH1750::begin(Mode mode) {
+bool BH1750::begin(Mode mode, byte addr, TwoWire *i2c) {
 
   // I2C is expected to be initialized outside this library
+  // But, allows a different address and TwoWire instance to be used
+  if(i2c) {
+    I2C = i2c;
+  }
+  if(addr) {
+    BH1750_I2CADDR = addr;
+  }
 
   // Configure sensor in specified mode
   return configure(mode);
@@ -91,9 +101,9 @@ bool BH1750::configure(Mode mode) {
     case BH1750::ONE_TIME_LOW_RES_MODE:
 
       // Send mode to sensor
-      Wire.beginTransmission(BH1750_I2CADDR);
+      I2C->beginTransmission(BH1750_I2CADDR);
       __wire_write((uint8_t)BH1750_MODE);
-      ack = Wire.endTransmission();
+      ack = I2C->endTransmission();
 
       // Wait a few moments to wake up
       _delay_ms(10);
@@ -149,15 +159,15 @@ bool BH1750::setMTreg(byte MTreg) {
   // Send MTreg and the current mode to the sensor
   //   High bit: 01000_MT[7,6,5]
   //    Low bit: 011_MT[4,3,2,1,0]
-  Wire.beginTransmission(BH1750_I2CADDR);
+  I2C->beginTransmission(BH1750_I2CADDR);
   __wire_write((0b01000 << 3) | (MTreg >> 5));
-  ack = Wire.endTransmission();
-  Wire.beginTransmission(BH1750_I2CADDR);
+  ack = I2C->endTransmission();
+  I2C->beginTransmission(BH1750_I2CADDR);
   __wire_write((0b011 << 5 )  | (MTreg & 0b11111));
-  ack = ack | Wire.endTransmission();
-  Wire.beginTransmission(BH1750_I2CADDR);
+  ack = ack | I2C->endTransmission();
+  I2C->beginTransmission(BH1750_I2CADDR);
   __wire_write(BH1750_MODE);
-  ack = ack | Wire.endTransmission();
+  ack = ack | I2C->endTransmission();
 
   // Wait a few moments to wake up
   _delay_ms(10);
@@ -218,9 +228,9 @@ float BH1750::readLightLevel(bool maxWait) {
   float level = -1.0;
 
   // Send mode to sensor
-  Wire.beginTransmission(BH1750_I2CADDR);
+  I2C->beginTransmission(BH1750_I2CADDR);
   __wire_write((uint8_t)BH1750_MODE);
-  Wire.endTransmission();
+  I2C->endTransmission();
 
   // Wait for measurement to be taken.
   // Measurements have a maximum measurement time and a typical measurement
@@ -247,7 +257,7 @@ float BH1750::readLightLevel(bool maxWait) {
 
   // Read two bytes from the sensor, which are low and high parts of the sensor
   // value
-  if (2 == Wire.requestFrom((int)BH1750_I2CADDR, (int)2)) {
+  if (2 == I2C->requestFrom((int)BH1750_I2CADDR, (int)2)) {
     unsigned int tmp = 0;
     tmp = __wire_read();
     tmp <<= 8;

--- a/BH1750.h
+++ b/BH1750.h
@@ -60,7 +60,8 @@ class BH1750 {
     };
 
     BH1750(byte addr = 0x23);
-    bool begin(Mode mode = CONTINUOUS_HIGH_RES_MODE);
+    bool begin(Mode mode = CONTINUOUS_HIGH_RES_MODE, byte addr = 0x23,
+               TwoWire* i2c = nullptr);
     bool configure(Mode mode);
     bool setMTreg(byte MTreg);
     float readLightLevel(bool maxWait = false);
@@ -73,7 +74,7 @@ class BH1750 {
     // for more information.
     const float BH1750_CONV_FACTOR = 1.2;
     Mode BH1750_MODE = UNCONFIGURED;
-
+    TwoWire* I2C;
 };
 
 #endif

--- a/examples/BH1750two_i2c/BH1750two_i2c.ino
+++ b/examples/BH1750two_i2c/BH1750two_i2c.ino
@@ -1,0 +1,71 @@
+/*
+
+  Example of BH1750 library usage.
+
+  This example initialises two BH1750 objects using different TwoWire
+  instances (Wire and Wire1) and then makes a light level reading every second.
+  This is the case for boards such as the ESP8266 and ESP32
+
+  Connection:
+
+    BH1750 A:
+      VCC -> 3V3 or 5V
+      GND -> GND
+      SCL -> SCL (19 in this example)
+      SDA -> SDA (18 in this example)
+      ADD -> (not connected) or GND
+
+    BH1750 B:
+      VCC -> 3V3 or 5V
+      GND -> GND
+      SCL -> SCL (22 in this example)
+      SDA -> SDA (21 in this example)
+      ADD -> (not connected) or GND
+
+  ADD pin is used to set sensor I2C address. If it has voltage greater or equal to
+  0.7VCC voltage (e.g. you've connected it to VCC) the sensor address will be
+  0x5C. In other case (if ADD voltage less than 0.7 * VCC) the sensor address will
+  be 0x23 (by default).
+
+*/
+
+#include "BH1750.h"
+#include "Wire.h"
+
+BH1750 bh1750_a;
+BH1750 bh1750_b;
+
+void setup() {
+  Serial.begin(115200);
+  Wire.begin(18, 19);
+  Wire1.begin(21, 22);
+  bh1750_a.begin(BH1750::CONTINUOUS_HIGH_RES_MODE, 0x23, &Wire);
+  bh1750_b.begin(BH1750::CONTINUOUS_HIGH_RES_MODE, 0x23, &Wire1);
+}
+
+int error_counter_1_a = 0;
+int error_counter_2_a = 0;
+int error_counter_1_b = 0;
+int error_counter_2_b = 0;
+
+void loop() {
+  const float light_level_a = bh1750_a.readLightLevel();
+  const float light_level_b = bh1750_b.readLightLevel();
+
+  if (lround(light_level_a) == -1) {
+    error_counter_1_a++;
+  }
+  if (lround(light_level_a) == -2) {
+    error_counter_2_a++;
+  }
+  if (lround(light_level_b) == -1) {
+    error_counter_1_b++;
+  }
+  if (lround(light_level_b) == -2) {
+    error_counter_2_b++;
+  }
+  Serial.printf("A: %.0f lux %d:%d :: B: %.0f lux %d:%d\n", light_level_a,
+                error_counter_1_a, error_counter_2_a, light_level_b,
+                error_counter_1_b, error_counter_2_b);
+  delay(1000);
+}


### PR DESCRIPTION
Why:

- Some boards have two or more I2C interfaces
- Fixes #50 
- Fixes #60 

This change addresses the need by:

- Extending the begin() function
- Replacing hard coded Wire calls with a TwoWire pointer