### PR TITLE
Wemos / Lolin D1 Mini Pro uses Wire.begin(D2, D1);

### DIFF
--- a/examples/BH1750test/BH1750test.ino
+++ b/examples/BH1750test/BH1750test.ino
@@ -34,6 +34,7 @@ void setup(){
   // Initialize the I2C bus (BH1750 library doesn't do this automatically)
   Wire.begin();
   // On esp8266 you can select SCL and SDA pins using Wire.begin(D4, D3);
+  // For Wemos / Lolin D1 Mini Pro and the Ambient Light shield use Wire.begin(D2, D1);
 
   lightMeter.begin();
 


### PR DESCRIPTION
Wemos / Lolin D1 Mini Pro doesn't use the standard ESP8266 pins, I've added a comment to say which ones to use.