### PR TITLE
BH1750 MTreg min is 31 in the datasheet

### DIFF
--- a/examples/BH1750autoadjust/BH1750autoadjust.ino
+++ b/examples/BH1750autoadjust/BH1750autoadjust.ino
@@ -12,7 +12,7 @@ lux <    10 ==> MTreg = 138
 Remember to test your specific sensor! Maybe the MTreg value range from 31
 up to 254 is not applicable to your unit.
 
-A calculated theoretical example of the absolute minimum and maximum lx values:
+A calculated theoretical example of the minimum resolution and maximum lx values:
   At CONTINUOUS_HIGH_RES_MODE and ONE_TIME_HIGH_RES_MODE,
   with BH1750_MTREG_MIN, BH1750_DEFAULT_MTREG and BH1750_MTREG_MAX:
     setMTreg( 31) ==> min.: 1.85 lx, max.: 121556.85 lx

--- a/examples/BH1750autoadjust/BH1750autoadjust.ino
+++ b/examples/BH1750autoadjust/BH1750autoadjust.ino
@@ -9,8 +9,21 @@ After the measurement the MTreg value is changed according to the result:
 lux > 40000 ==> MTreg =  32
 lux < 40000 ==> MTreg =  69  (default)
 lux <    10 ==> MTreg = 138
-Remember to test your specific sensor! Maybe the MTreg value range from 32
+Remember to test your specific sensor! Maybe the MTreg value range from 31
 up to 254 is not applicable to your unit.
+
+A calculated theoretical example of the absolute minimum and maximum lx values:
+  At CONTINUOUS_HIGH_RES_MODE and ONE_TIME_HIGH_RES_MODE,
+  with BH1750_MTREG_MIN, BH1750_DEFAULT_MTREG and BH1750_MTREG_MAX:
+    setMTreg( 31) ==> min.: 1.85 lx, max.: 121556.85 lx
+    setMTreg( 69) ==> min.: 0.83 lx, max.:  54612.50 lx
+    setMTreg(254) ==> min.: 0.23 lx, max.:  14835.68 lx
+
+  At CONTINUOUS_HIGH_RES_MODE_2 and ONE_TIME_HIGH_RES_MODE_2,
+  with BH1750_MTREG_MIN, BH1750_DEFAULT_MTREG and BH1750_MTREG_MAX:
+    setMTreg( 31) ==> min.: 0.93 lx, max.: 60778.43 lx
+    setMTreg( 69) ==> min.: 0.42 lx, max.: 27306.25 lx
+    setMTreg(254) ==> min.: 0.11 lx, max.:  7417.84 lx
 
 Connections
 

--- a/examples/BH1750autoadjust/BH1750autoadjust.ino
+++ b/examples/BH1750autoadjust/BH1750autoadjust.ino
@@ -12,19 +12,6 @@ lux <    10 ==> MTreg = 138
 Remember to test your specific sensor! Maybe the MTreg value range from 31
 up to 254 is not applicable to your unit.
 
-A calculated theoretical example of the minimum resolution and maximum lx values:
-  At CONTINUOUS_HIGH_RES_MODE and ONE_TIME_HIGH_RES_MODE,
-  with BH1750_MTREG_MIN, BH1750_DEFAULT_MTREG and BH1750_MTREG_MAX:
-    setMTreg( 31) ==> min.: 1.85 lx, max.: 121556.85 lx
-    setMTreg( 69) ==> min.: 0.83 lx, max.:  54612.50 lx
-    setMTreg(254) ==> min.: 0.23 lx, max.:  14835.68 lx
-
-  At CONTINUOUS_HIGH_RES_MODE_2 and ONE_TIME_HIGH_RES_MODE_2,
-  with BH1750_MTREG_MIN, BH1750_DEFAULT_MTREG and BH1750_MTREG_MAX:
-    setMTreg( 31) ==> min.: 0.93 lx, max.: 60778.43 lx
-    setMTreg( 69) ==> min.: 0.42 lx, max.: 27306.25 lx
-    setMTreg(254) ==> min.: 0.11 lx, max.:  7417.84 lx
-
 Connections
 
   - VCC to 3V3 or 5V

--- a/src/BH1750.cpp
+++ b/src/BH1750.cpp
@@ -138,13 +138,13 @@ bool BH1750::configure(Mode mode) {
 /**
  * Configure BH1750 MTreg value
  * MT reg = Measurement Time register
- * @param MTreg a value between 32 and 254. Default: 69
+ * @param MTreg a value between 31 and 254. Default: 69
  * @return bool true if MTReg successful set
  * 		false if MTreg not changed or parameter out of range
  */
 bool BH1750::setMTreg(byte MTreg) {
   // Bug: lowest value seems to be 32!
-  if (MTreg <= 31 || MTreg > 254) {
+  if (MTreg < BH1750_MTREG_MIN || MTreg > BH1750_MTREG_MAX) {
     Serial.println(F("[BH1750] ERROR: MTreg out of range"));
     return false;
   }

--- a/src/BH1750.cpp
+++ b/src/BH1750.cpp
@@ -143,7 +143,6 @@ bool BH1750::configure(Mode mode) {
  * 		false if MTreg not changed or parameter out of range
  */
 bool BH1750::setMTreg(byte MTreg) {
-  // Bug: lowest value seems to be 32!
   if (MTreg < BH1750_MTREG_MIN || MTreg > BH1750_MTREG_MAX) {
     Serial.println(F("[BH1750] ERROR: MTreg out of range"));
     return false;

--- a/src/BH1750.h
+++ b/src/BH1750.h
@@ -38,6 +38,8 @@
 
 // Default MTreg value
 #define BH1750_DEFAULT_MTREG 69
+#define BH1750_MTREG_MIN     (31)
+#define BH1750_MTREG_MAX     (254)
 
 class BH1750 {
 

--- a/src/BH1750.h
+++ b/src/BH1750.h
@@ -38,8 +38,8 @@
 
 // Default MTreg value
 #define BH1750_DEFAULT_MTREG 69
-#define BH1750_MTREG_MIN     (31)
-#define BH1750_MTREG_MAX     (254)
+#define BH1750_MTREG_MIN 31
+#define BH1750_MTREG_MAX 254
 
 class BH1750 {
 


### PR DESCRIPTION
a value of 31 should not be rejected.
in the datasheet min is 31:
![bh1740_mtreg_range](https://user-images.githubusercontent.com/4750719/149122142-a55e64bc-48ea-4b08-bfa1-fe4310ae7f8c.png)
