### PR TITLE
Request to implement possibility to block error messages if Serial bus is not used/connected

### DIFF
--- a/src/BH1750.cpp
+++ b/src/BH1750.cpp
@@ -106,8 +106,8 @@ bool BH1750::configure(Mode mode) {
   default:
     // Print error message if error debug enabled
     // SELECTED INVALID MEASURE MODE
-    #ifdef BH1750_DEBUG_ERROR
-    Serial.println(F("[BH1750] ERROR: Invalid mode"));
+    #ifdef BH1750_DEBUG_ERRORS
+      BH1750_LOG(BH1750_INVALID_MODE);
     #endif
     break;
   }
@@ -121,36 +121,36 @@ bool BH1750::configure(Mode mode) {
   case 1:
     // Print error message if error debug enabled
     // MESSAGE IS TOO LONG FOR TRANSMIT BUFFER
-    #ifdef BH1750_DEBUG_ERROR
-    Serial.println(F("[BH1750] ERROR: too long for transmit buffer"));
+    #ifdef BH1750_DEBUG_ERRORS
+      BH1750_LOG(BH1750_BUFFER_OVERFLOW);
     #endif
     break;
   case 2:
     // Print error message if error debug enabled
     // RECEIVED NACK ON TRANSMIT OF ADDRESS
-    #ifdef BH1750_DEBUG_ERROR
-    Serial.println(F("[BH1750] ERROR: received NACK on transmit of address"));
+    #ifdef BH1750_DEBUG_ERRORS
+      BH1750_LOG(BH1750_ADDRESS_NACK);
     #endif
     break;
   case 3:
     // Print error message if error debug enabled
     // RECEIVED NACK ON TRANSMIT OF DATA
-    #ifdef BH1750_DEBUG_ERROR
-    Serial.println(F("[BH1750] ERROR: received NACK on transmit of data"));
+    #ifdef BH1750_DEBUG_ERRORS
+      BH1750_LOG(BH1750_DATA_NACK);
     #endif
     break;
   case 4:
     // Print error message if error debug enabled
     // OTHER WIRE BUS ERROR
-    #ifdef BH1750_DEBUG_ERROR
-    Serial.println(F("[BH1750] ERROR: other error"));
+    #ifdef BH1750_DEBUG_ERRORS
+      BH1750_LOG(BH1750_OTHER_ERROR);
     #endif
     break;
   default:
     // Print error message if error debug enabled
     // UNDEFINED ERROR
-    #ifdef BH1750_DEBUG_ERROR
-    Serial.println(F("[BH1750] ERROR: undefined error"));
+    #ifdef BH1750_DEBUG_ERRORS
+      BH1750_LOG(BH1750_UNDEFINED_ERROR);
     #endif
     break;
   }
@@ -169,8 +169,8 @@ bool BH1750::setMTreg(byte MTreg) {
   if (MTreg < BH1750_MTREG_MIN || MTreg > BH1750_MTREG_MAX) {
     // Print error message if error debug enabled
     // MTREG OUT OF RANGE
-    #ifdef BH1750_DEBUG_ERROR
-    Serial.println(F("[BH1750] ERROR: MTreg out of range"));
+    #ifdef BH1750_DEBUG_ERRORS
+      BH1750_LOG(BH1750_MTREG_OUT_OF_RANGE);
     #endif
     return false;
   }
@@ -199,36 +199,36 @@ bool BH1750::setMTreg(byte MTreg) {
   case 1:
     // Print error message if error debug enabled
     // MESSAGE IS TOO LONG FOR TRANSMIT BUFFER
-    #ifdef BH1750_DEBUG_ERROR
-    Serial.println(F("[BH1750] ERROR: too long for transmit buffer"));
+    #ifdef BH1750_DEBUG_ERRORS
+      BH1750_LOG(BH1750_BUFFER_OVERFLOW);
     #endif
     break;
   case 2:
     // Print error message if error debug enabled
     // RECEIVED NACK ON TRANSMIT OF ADDRESS
-    #ifdef BH1750_DEBUG_ERROR
-    Serial.println(F("[BH1750] ERROR: received NACK on transmit of address"));
+    #ifdef BH1750_DEBUG_ERRORS
+      BH1750_LOG(BH1750_ADDRESS_NACK);
     #endif
     break;
   case 3: 
     // Print error message if error debug enabled
     // RECEIVED NACK ON TRANSMIT OF DATA
-    #ifdef BH1750_DEBUG_ERROR
-    Serial.println(F("[BH1750] ERROR: received NACK on transmit of data"));
+    #ifdef BH1750_DEBUG_ERRORS
+      BH1750_LOG(BH1750_DATA_NACK);
     #endif
     break;
   case 4:
     // Print error message if error debug enabled
     // OTHER WIRE BUS ERROR
-    #ifdef BH1750_DEBUG_ERROR
-    Serial.println(F("[BH1750] ERROR: other error"));
+    #ifdef BH1750_DEBUG_ERRORS
+      BH1750_LOG(BH1750_OTHER_ERROR);
     #endif
     break;
   default:
     // Print error message if error debug enabled
     // UNDEFINED ERROR
-    #ifdef BH1750_DEBUG_ERROR
-    Serial.println(F("[BH1750] ERROR: undefined error"));
+    #ifdef BH1750_DEBUG_ERRORS
+      BH1750_LOG(BH1750_UNDEFINED_ERROR);
     #endif
     break;
   }
@@ -288,8 +288,8 @@ float BH1750::readLightLevel() {
   if (BH1750_MODE == UNCONFIGURED) {
     // Print error message if error debug enabled
     // DEVICE IS NOT CONFIGURED
-    #ifdef BH1750_DEBUG_ERROR
-    Serial.println(F("[BH1750] Device is not configured!"));
+    #ifdef BH1750_DEBUG_ERRORS
+      BH1750_LOG(BH1750_SENSOR_UNCONFIGURED);
     #endif
     return -2.0;
   }
@@ -309,20 +309,17 @@ float BH1750::readLightLevel() {
   lastReadTimestamp = millis();
 
   if (level != -1.0) {
-// Print raw value if debug enabled
-#ifdef BH1750_DEBUG_VALUE
-    Serial.print(F("[BH1750] Raw value: "));
-    Serial.println(level);
-#endif
+    // Print raw value if debug enabled
+    #ifdef BH1750_DEBUG_VALUES
+      BH1750_LOG(BH1750_RAW_VALUE_FORMAT, level);
+    #endif
 
     if (BH1750_MTreg != BH1750_DEFAULT_MTREG) {
       level *= (float)((byte)BH1750_DEFAULT_MTREG / (float)BH1750_MTreg);
-// Print MTreg factor if debug enabled
-#ifdef BH1750_DEBUG_VALUE
-      Serial.print(F("[BH1750] MTreg factor: "));
-      Serial.println(
-          String((float)((byte)BH1750_DEFAULT_MTREG / (float)BH1750_MTreg)));
-#endif
+      // Print MTreg factor if debug enabled
+      #ifdef BH1750_DEBUG_VALUES
+        BH1750_LOG(BH1750_MTREG_FACTOR_FORMAT, (float)((byte)BH1750_DEFAULT_MTREG / (float)BH1750_MTreg));
+      #endif
     }
     if (BH1750_MODE == BH1750::ONE_TIME_HIGH_RES_MODE_2 ||
         BH1750_MODE == BH1750::CONTINUOUS_HIGH_RES_MODE_2) {
@@ -331,11 +328,10 @@ float BH1750::readLightLevel() {
     // Convert raw value to lux
     level /= BH1750_CONV_FACTOR;
 
-// Print converted value if value debug enabled
-#ifdef BH1750_DEBUG_VALUE
-    Serial.print(F("[BH1750] Converted float value: "));
-    Serial.println(level);
-#endif
+    // Print converted value if value debug enabled
+    #ifdef BH1750_DEBUG_VALUES
+      BH1750_LOG(BH1750_CONVERTED_VALUE_FORMAT, level);
+    #endif
   }
 
   return level;

--- a/src/BH1750.cpp
+++ b/src/BH1750.cpp
@@ -104,8 +104,11 @@ bool BH1750::configure(Mode mode) {
     break;
 
   default:
-    // Invalid measurement mode
+    // Print error message if error debug enabled
+    // SELECTED INVALID MEASURE MODE
+    #ifdef BH1750_DEBUG_ERROR
     Serial.println(F("[BH1750] ERROR: Invalid mode"));
+    #endif
     break;
   }
 
@@ -115,20 +118,40 @@ bool BH1750::configure(Mode mode) {
     BH1750_MODE = mode;
     lastReadTimestamp = millis();
     return true;
-  case 1: // too long for transmit buffer
+  case 1:
+    // Print error message if error debug enabled
+    // MESSAGE IS TOO LONG FOR TRANSMIT BUFFER
+    #ifdef BH1750_DEBUG_ERROR
     Serial.println(F("[BH1750] ERROR: too long for transmit buffer"));
+    #endif
     break;
-  case 2: // received NACK on transmit of address
+  case 2:
+    // Print error message if error debug enabled
+    // RECEIVED NACK ON TRANSMIT OF ADDRESS
+    #ifdef BH1750_DEBUG_ERROR
     Serial.println(F("[BH1750] ERROR: received NACK on transmit of address"));
+    #endif
     break;
-  case 3: // received NACK on transmit of data
+  case 3:
+    // Print error message if error debug enabled
+    // RECEIVED NACK ON TRANSMIT OF DATA
+    #ifdef BH1750_DEBUG_ERROR
     Serial.println(F("[BH1750] ERROR: received NACK on transmit of data"));
+    #endif
     break;
-  case 4: // other error
+  case 4:
+    // Print error message if error debug enabled
+    // OTHER WIRE BUS ERROR
+    #ifdef BH1750_DEBUG_ERROR
     Serial.println(F("[BH1750] ERROR: other error"));
+    #endif
     break;
   default:
+    // Print error message if error debug enabled
+    // UNDEFINED ERROR
+    #ifdef BH1750_DEBUG_ERROR
     Serial.println(F("[BH1750] ERROR: undefined error"));
+    #endif
     break;
   }
 
@@ -144,7 +167,11 @@ bool BH1750::configure(Mode mode) {
  */
 bool BH1750::setMTreg(byte MTreg) {
   if (MTreg < BH1750_MTREG_MIN || MTreg > BH1750_MTREG_MAX) {
+    // Print error message if error debug enabled
+    // MTREG OUT OF RANGE
+    #ifdef BH1750_DEBUG_ERROR
     Serial.println(F("[BH1750] ERROR: MTreg out of range"));
+    #endif
     return false;
   }
   byte ack = 5;
@@ -169,20 +196,40 @@ bool BH1750::setMTreg(byte MTreg) {
   case 0:
     BH1750_MTreg = MTreg;
     return true;
-  case 1: // too long for transmit buffer
+  case 1:
+    // Print error message if error debug enabled
+    // MESSAGE IS TOO LONG FOR TRANSMIT BUFFER
+    #ifdef BH1750_DEBUG_ERROR
     Serial.println(F("[BH1750] ERROR: too long for transmit buffer"));
+    #endif
     break;
-  case 2: // received NACK on transmit of address
+  case 2:
+    // Print error message if error debug enabled
+    // RECEIVED NACK ON TRANSMIT OF ADDRESS
+    #ifdef BH1750_DEBUG_ERROR
     Serial.println(F("[BH1750] ERROR: received NACK on transmit of address"));
+    #endif
     break;
-  case 3: // received NACK on transmit of data
+  case 3: 
+    // Print error message if error debug enabled
+    // RECEIVED NACK ON TRANSMIT OF DATA
+    #ifdef BH1750_DEBUG_ERROR
     Serial.println(F("[BH1750] ERROR: received NACK on transmit of data"));
+    #endif
     break;
-  case 4: // other error
+  case 4:
+    // Print error message if error debug enabled
+    // OTHER WIRE BUS ERROR
+    #ifdef BH1750_DEBUG_ERROR
     Serial.println(F("[BH1750] ERROR: other error"));
+    #endif
     break;
   default:
+    // Print error message if error debug enabled
+    // UNDEFINED ERROR
+    #ifdef BH1750_DEBUG_ERROR
     Serial.println(F("[BH1750] ERROR: undefined error"));
+    #endif
     break;
   }
 
@@ -239,7 +286,11 @@ bool BH1750::measurementReady(bool maxWait) {
 float BH1750::readLightLevel() {
 
   if (BH1750_MODE == UNCONFIGURED) {
+    // Print error message if error debug enabled
+    // DEVICE IS NOT CONFIGURED
+    #ifdef BH1750_DEBUG_ERROR
     Serial.println(F("[BH1750] Device is not configured!"));
+    #endif
     return -2.0;
   }
 
@@ -259,7 +310,7 @@ float BH1750::readLightLevel() {
 
   if (level != -1.0) {
 // Print raw value if debug enabled
-#ifdef BH1750_DEBUG
+#ifdef BH1750_DEBUG_VALUE
     Serial.print(F("[BH1750] Raw value: "));
     Serial.println(level);
 #endif
@@ -267,7 +318,7 @@ float BH1750::readLightLevel() {
     if (BH1750_MTreg != BH1750_DEFAULT_MTREG) {
       level *= (float)((byte)BH1750_DEFAULT_MTREG / (float)BH1750_MTreg);
 // Print MTreg factor if debug enabled
-#ifdef BH1750_DEBUG
+#ifdef BH1750_DEBUG_VALUE
       Serial.print(F("[BH1750] MTreg factor: "));
       Serial.println(
           String((float)((byte)BH1750_DEFAULT_MTREG / (float)BH1750_MTreg)));
@@ -280,8 +331,8 @@ float BH1750::readLightLevel() {
     // Convert raw value to lux
     level /= BH1750_CONV_FACTOR;
 
-// Print converted value if debug enabled
-#ifdef BH1750_DEBUG
+// Print converted value if value debug enabled
+#ifdef BH1750_DEBUG_VALUE
     Serial.print(F("[BH1750] Converted float value: "));
     Serial.println(level);
 #endif

--- a/src/BH1750.cpp
+++ b/src/BH1750.cpp
@@ -81,7 +81,7 @@ bool BH1750::begin(Mode mode, byte addr, TwoWire* i2c) {
  */
 bool BH1750::configure(Mode mode) {
 
-  // default transmission result to a value out of normal range
+  // Default transmission result to a value out of normal range
   byte ack = 5;
 
   // Check measurement mode is valid
@@ -104,8 +104,7 @@ bool BH1750::configure(Mode mode) {
     break;
 
   default:
-    // Print error message if error debug enabled
-    // SELECTED INVALID MEASURE MODE
+    // Selected invalid measure mode
     #ifdef BH1750_DEBUG_ERRORS
       BH1750_LOG(BH1750_INVALID_MODE);
     #endif
@@ -119,36 +118,31 @@ bool BH1750::configure(Mode mode) {
     lastReadTimestamp = millis();
     return true;
   case 1:
-    // Print error message if error debug enabled
-    // MESSAGE IS TOO LONG FOR TRANSMIT BUFFER
+    // Message is too long for transmit buffer
     #ifdef BH1750_DEBUG_ERRORS
       BH1750_LOG(BH1750_BUFFER_OVERFLOW);
     #endif
     break;
   case 2:
-    // Print error message if error debug enabled
-    // RECEIVED NACK ON TRANSMIT OF ADDRESS
+    // Received NACK on transmit of address
     #ifdef BH1750_DEBUG_ERRORS
       BH1750_LOG(BH1750_ADDRESS_NACK);
     #endif
     break;
   case 3:
-    // Print error message if error debug enabled
-    // RECEIVED NACK ON TRANSMIT OF DATA
+    // Received NACK on transmit of data
     #ifdef BH1750_DEBUG_ERRORS
       BH1750_LOG(BH1750_DATA_NACK);
     #endif
     break;
   case 4:
-    // Print error message if error debug enabled
-    // OTHER WIRE BUS ERROR
+    // Other Wire bus error
     #ifdef BH1750_DEBUG_ERRORS
       BH1750_LOG(BH1750_OTHER_ERROR);
     #endif
     break;
   default:
-    // Print error message if error debug enabled
-    // UNDEFINED ERROR
+    // Undefined error
     #ifdef BH1750_DEBUG_ERRORS
       BH1750_LOG(BH1750_UNDEFINED_ERROR);
     #endif
@@ -167,8 +161,7 @@ bool BH1750::configure(Mode mode) {
  */
 bool BH1750::setMTreg(byte MTreg) {
   if (MTreg < BH1750_MTREG_MIN || MTreg > BH1750_MTREG_MAX) {
-    // Print error message if error debug enabled
-    // MTREG OUT OF RANGE
+    // MTreg out of range
     #ifdef BH1750_DEBUG_ERRORS
       BH1750_LOG(BH1750_MTREG_OUT_OF_RANGE);
     #endif
@@ -197,35 +190,30 @@ bool BH1750::setMTreg(byte MTreg) {
     BH1750_MTreg = MTreg;
     return true;
   case 1:
-    // Print error message if error debug enabled
     // MESSAGE IS TOO LONG FOR TRANSMIT BUFFER
     #ifdef BH1750_DEBUG_ERRORS
       BH1750_LOG(BH1750_BUFFER_OVERFLOW);
     #endif
     break;
   case 2:
-    // Print error message if error debug enabled
     // RECEIVED NACK ON TRANSMIT OF ADDRESS
     #ifdef BH1750_DEBUG_ERRORS
       BH1750_LOG(BH1750_ADDRESS_NACK);
     #endif
     break;
   case 3: 
-    // Print error message if error debug enabled
     // RECEIVED NACK ON TRANSMIT OF DATA
     #ifdef BH1750_DEBUG_ERRORS
       BH1750_LOG(BH1750_DATA_NACK);
     #endif
     break;
   case 4:
-    // Print error message if error debug enabled
     // OTHER WIRE BUS ERROR
     #ifdef BH1750_DEBUG_ERRORS
       BH1750_LOG(BH1750_OTHER_ERROR);
     #endif
     break;
   default:
-    // Print error message if error debug enabled
     // UNDEFINED ERROR
     #ifdef BH1750_DEBUG_ERRORS
       BH1750_LOG(BH1750_UNDEFINED_ERROR);
@@ -286,7 +274,6 @@ bool BH1750::measurementReady(bool maxWait) {
 float BH1750::readLightLevel() {
 
   if (BH1750_MODE == UNCONFIGURED) {
-    // Print error message if error debug enabled
     // DEVICE IS NOT CONFIGURED
     #ifdef BH1750_DEBUG_ERRORS
       BH1750_LOG(BH1750_SENSOR_UNCONFIGURED);
@@ -309,14 +296,14 @@ float BH1750::readLightLevel() {
   lastReadTimestamp = millis();
 
   if (level != -1.0) {
-    // Print raw value if debug enabled
+    // Print raw value if value debug enabled
     #ifdef BH1750_DEBUG_VALUES
       BH1750_LOG(BH1750_RAW_VALUE_FORMAT, level);
     #endif
 
     if (BH1750_MTreg != BH1750_DEFAULT_MTREG) {
       level *= (float)((byte)BH1750_DEFAULT_MTREG / (float)BH1750_MTreg);
-      // Print MTreg factor if debug enabled
+      // Print MTreg factor if value debug enabled
       #ifdef BH1750_DEBUG_VALUES
         BH1750_LOG(BH1750_MTREG_FACTOR_FORMAT, (float)((byte)BH1750_DEFAULT_MTREG / (float)BH1750_MTreg));
       #endif

--- a/src/BH1750.h
+++ b/src/BH1750.h
@@ -22,12 +22,17 @@
 #  include <WProgram.h>
 #endif
 
-#include "Wire.h"
+#include <Wire.h>
 
-// Uncomment, to enable measured values debug messages
-// #define BH1750_DEBUG_VALUE
-// Uncomment, to enable error messages
-// #define BH1750_DEBUG_ERROR
+#include "BH1750messages.h"
+
+// Uncomment to enable measured values debug messages
+// #define BH1750_DEBUG_VALUES
+//
+// Uncomment to enable error messages
+// #define BH1750_DEBUG_ERRORS
+//
+// To customise debug messages see BH1750messages.h file
 
 // No active state
 #define BH1750_POWER_DOWN 0x00

--- a/src/BH1750.h
+++ b/src/BH1750.h
@@ -24,8 +24,10 @@
 
 #include "Wire.h"
 
-// Uncomment, to enable debug messages
-// #define BH1750_DEBUG
+// Uncomment, to enable measured values debug messages
+// #define BH1750_DEBUG_VALUE
+// Uncomment, to enable error messages
+// #define BH1750_DEBUG_ERROR
 
 // No active state
 #define BH1750_POWER_DOWN 0x00

--- a/src/BH1750messages.h
+++ b/src/BH1750messages.h
@@ -18,7 +18,7 @@
 
 /*
   A default style of the debug messages, to modify a look of the debug message
-  or to use a custom command just define own BH1750_LOG command macro
+  or to use a custom command just define own BH1750_LOG command macro.
 
   Template for your custom format (replace square brackets by your own text):
   #  define BH1750_LOG(fmt, ...) Serial.printf(                              \
@@ -42,71 +42,71 @@
                   (double)millis() / 1000.0, ##__VA_ARGS__)
 #endif // !BH1750_LOG
 
-// This error message shows when invalid measurement mode is selected
-// No additional formatting parameters (e.g. %d) allowed
+// This error message shows when invalid measurement mode is selected.
+// No additional formatting parameters (e.g. %d) allowed.
 #ifndef BH1750_INVALID_MODE
 #  define BH1750_INVALID_MODE "Error: Invalid mode"
 #endif // !BH1750_INVALID_MODE
 
 // This error message shows when buffer of the Wire bus has not insufficient
-// space to send data No additional formatting parameters (e.g. %d) allowed
+// space to send data. No additional formatting parameters (e.g. %d) allowed.
 #ifndef BH1750_BUFFER_OVERFLOW
 #  define BH1750_BUFFER_OVERFLOW "Error: Data are too long for transmit buffer"
 #endif // !BH1750_BUFFER_OVERFLOW
 
 // This error message shows when the Wire bus cannot reach the sensor
-// (e.g. sensor is disconnected or was used wrong address)
-// No additional formatting parameters (e.g. %d) allowed
+// (e.g. sensor is disconnected or was used wrong address).
+// No additional formatting parameters (e.g. %d) allowed.
 #ifndef BH1750_ADDRESS_NACK
 #  define BH1750_ADDRESS_NACK "Error: Received NACK on transmit of address"
 #endif // !BH1750_ADDRESS_NACK
 
 // This error message shows when the sensor receives invalid data/command or
-// it's buffer overflows No additional formatting parameters (e.g. %d) allowed
+// it's buffer overflows. No additional formatting parameters (e.g. %d) allowed.
 #ifndef BH1750_DATA_NACK
 #  define BH1750_DATA_NACK "Error: Received NACK on transmit of data"
 #endif // !BH1750_DATA_NACK
 
-// This error message shows when an other error of the Wire bus appears
-// No additional formatting parameters (e.g. %d) allowed
+// This error message shows when an other error of the Wire bus appears.
+// No additional formatting parameters (e.g. %d) allowed.
 #ifndef BH1750_OTHER_ERROR
 #  define BH1750_OTHER_ERROR "Error: Other error of the bus"
 #endif // !BH1750_OTHER_ERROR
 
-// This error message shows when an undefined error of the Wire bus appears
-// No additional formatting parameters (e.g. %d) allowed
+// This error message shows when an undefined error of the Wire bus appears.
+// No additional formatting parameters (e.g. %d) allowed.
 #ifndef BH1750_UNDEFINED_ERROR
 #  define BH1750_UNDEFINED_ERROR "Error: Undefined error of the bus"
 #endif // !BH1750_UNDEFINED_ERROR
 
-// This error message shows when entered measurement time is out of allowed
-// range No additional formatting parameters (e.g. %d) allowed
+// This error message shows when entered measurement time is out of allowed.
+// range No additional formatting parameters (e.g. %d) allowed.
 #ifndef BH1750_MTREG_OUT_OF_RANGE
 #  define BH1750_MTREG_OUT_OF_RANGE "Error: MTreg value is out of range"
 #endif // !BH1750_MTREG_OUT_OF_RANGE
 
-// This error message shows when the sensor has not been initialized yet
-// No additional formatting parameters (e.g. %d) allowed
+// This error message shows when the sensor has not been initialized yet.
+// No additional formatting parameters (e.g. %d) allowed.
 #ifndef BH1750_SENSOR_UNCONFIGURED
 #  define BH1750_SENSOR_UNCONFIGURED "Error: Device is not configured"
 #endif // !BH1750_SENSOR_UNCONFIGURED
 
 // The format of sensor's raw value output shown when the debug of values is
-// enabled Formatting parameter "%f" must be present in the message
+// enabled. Formatting parameter "%f" must be present in the message.
 #ifndef BH1750_RAW_VALUE_FORMAT
 #  define BH1750_RAW_VALUE_FORMAT "Raw value: %f"
 #endif // !BH1750_RAW_VALUE_FORMAT
 
-// The format of sensor's MTreg factor shown when the debug of values is enabled
-// MTreg is defined as ratio of the default MTreg value and setted value
-// Formatting parameter "%f" must be present in the message
+// The format of sensor's MTreg factor shown when the debug of values is
+// enabled. MTreg is defined as ratio of the default MTreg value and setted
+// value. Formatting parameter "%f" must be present in the message.
 #ifndef BH1750_MTREG_FACTOR_FORMAT
 #  define BH1750_MTREG_FACTOR_FORMAT "Raw value: %f"
 #endif // !BH1750_MTREG_FACTOR_FORMAT
 
-// The format of sensor's MTreg factor shown when the debug of values is enabled
-// MTreg is defined as ratio of the default MTreg value and setted value
-// Formatting parameter "%f" must be present in the message
+// The format of sensor's MTreg factor shown when the debug of values is
+// enabled. MTreg is defined as ratio of the default MTreg value and setted
+// value. Formatting parameter "%f" must be present in the message.
 #ifndef BH1750_CONVERTED_VALUE_FORMAT
 #  define BH1750_CONVERTED_VALUE_FORMAT "Converted value: %f"
 #endif // !BH1750_CONVERTED_VALUE_FORMAT

--- a/src/BH1750messages.h
+++ b/src/BH1750messages.h
@@ -37,73 +37,71 @@
   17:28:32.478 ->       3920.563 sec. -> [BH1750] Raw value: 32568.50
 */
 #ifndef BH1750_LOG
-#  define BH1750_LOG(fmt, ...) Serial.printf(       \
-      "% 9.3f sec. -> [BH1750] " fmt "\n",          \
-      (double)millis() / 1000.0,                    \
-      ##__VA_ARGS__                                 \
-      )
+#  define BH1750_LOG(fmt, ...)                                                 \
+    Serial.printf("% 9.3f sec. -> [BH1750] " fmt "\n",                         \
+                  (double)millis() / 1000.0, ##__VA_ARGS__)
 #endif // !BH1750_LOG
 
 // This error message shows when invalid measurement mode is selected
 // No additional formatting parameters (e.g. %d) allowed
 #ifndef BH1750_INVALID_MODE
-#    define BH1750_INVALID_MODE         "Error: Invalid mode"
+#  define BH1750_INVALID_MODE "Error: Invalid mode"
 #endif // !BH1750_INVALID_MODE
 
-// This error message shows when buffer of the Wire bus has not insufficient space to send data
-// No additional formatting parameters (e.g. %d) allowed
+// This error message shows when buffer of the Wire bus has not insufficient
+// space to send data No additional formatting parameters (e.g. %d) allowed
 #ifndef BH1750_BUFFER_OVERFLOW
-#  define BH1750_BUFFER_OVERFLOW        "Error: Data are too long for transmit buffer"
+#  define BH1750_BUFFER_OVERFLOW "Error: Data are too long for transmit buffer"
 #endif // !BH1750_BUFFER_OVERFLOW
 
-// This error message shows when the Wire bus cannot reach the sensor 
+// This error message shows when the Wire bus cannot reach the sensor
 // (e.g. sensor is disconnected or was used wrong address)
 // No additional formatting parameters (e.g. %d) allowed
 #ifndef BH1750_ADDRESS_NACK
-#    define BH1750_ADDRESS_NACK         "Error: Received NACK on transmit of address"
+#  define BH1750_ADDRESS_NACK "Error: Received NACK on transmit of address"
 #endif // !BH1750_ADDRESS_NACK
 
-// This error message shows when the sensor receives invalid data/command or it's buffer overflows
-// No additional formatting parameters (e.g. %d) allowed
+// This error message shows when the sensor receives invalid data/command or
+// it's buffer overflows No additional formatting parameters (e.g. %d) allowed
 #ifndef BH1750_DATA_NACK
-#  define BH1750_DATA_NACK              "Error: Received NACK on transmit of data"
+#  define BH1750_DATA_NACK "Error: Received NACK on transmit of data"
 #endif // !BH1750_DATA_NACK
 
 // This error message shows when an other error of the Wire bus appears
 // No additional formatting parameters (e.g. %d) allowed
 #ifndef BH1750_OTHER_ERROR
-#  define BH1750_OTHER_ERROR            "Error: Other error of the bus"
+#  define BH1750_OTHER_ERROR "Error: Other error of the bus"
 #endif // !BH1750_OTHER_ERROR
 
 // This error message shows when an undefined error of the Wire bus appears
 // No additional formatting parameters (e.g. %d) allowed
 #ifndef BH1750_UNDEFINED_ERROR
-#  define BH1750_UNDEFINED_ERROR        "Error: Undefined error of the bus"
+#  define BH1750_UNDEFINED_ERROR "Error: Undefined error of the bus"
 #endif // !BH1750_UNDEFINED_ERROR
 
-// This error message shows when entered measurement time is out of allowed range
-// No additional formatting parameters (e.g. %d) allowed
+// This error message shows when entered measurement time is out of allowed
+// range No additional formatting parameters (e.g. %d) allowed
 #ifndef BH1750_MTREG_OUT_OF_RANGE
-#  define BH1750_MTREG_OUT_OF_RANGE     "Error: MTreg value is out of range"
+#  define BH1750_MTREG_OUT_OF_RANGE "Error: MTreg value is out of range"
 #endif // !BH1750_MTREG_OUT_OF_RANGE
 
 // This error message shows when the sensor has not been initialized yet
 // No additional formatting parameters (e.g. %d) allowed
 #ifndef BH1750_SENSOR_UNCONFIGURED
-#  define BH1750_SENSOR_UNCONFIGURED    "Error: Device is not configured"
+#  define BH1750_SENSOR_UNCONFIGURED "Error: Device is not configured"
 #endif // !BH1750_SENSOR_UNCONFIGURED
 
-// The format of sensor's raw value output shown when the debug of values is enabled
-// Formatting parameter "%f" must be present in the message
+// The format of sensor's raw value output shown when the debug of values is
+// enabled Formatting parameter "%f" must be present in the message
 #ifndef BH1750_RAW_VALUE_FORMAT
-#  define BH1750_RAW_VALUE_FORMAT       "Raw value: %f"
+#  define BH1750_RAW_VALUE_FORMAT "Raw value: %f"
 #endif // !BH1750_RAW_VALUE_FORMAT
 
 // The format of sensor's MTreg factor shown when the debug of values is enabled
 // MTreg is defined as ratio of the default MTreg value and setted value
 // Formatting parameter "%f" must be present in the message
 #ifndef BH1750_MTREG_FACTOR_FORMAT
-#  define BH1750_MTREG_FACTOR_FORMAT    "Raw value: %f"
+#  define BH1750_MTREG_FACTOR_FORMAT "Raw value: %f"
 #endif // !BH1750_MTREG_FACTOR_FORMAT
 
 // The format of sensor's MTreg factor shown when the debug of values is enabled

--- a/src/BH1750messages.h
+++ b/src/BH1750messages.h
@@ -1,0 +1,116 @@
+/*
+
+  This is a library for the BH1750FVI Digital Light Sensor breakout board.
+
+  The BH1750 board uses I2C for communication. Two pins are required to
+  interface to the device. Configuring the I2C bus is expected to be done
+  in user code. The BH1750 library doesn't do this automatically.
+
+  Datasheet:
+  http://www.elechouse.com/elechouse/images/product/Digital%20light%20Sensor/bh1750fvi-e.pdf
+
+  Written by Christopher Laws, March, 2013.
+
+*/
+
+#ifndef BH1750messages_h
+#define BH1750messages_h
+
+/*
+  A default style of the debug messages, to modify a look of the debug message
+  or to use a custom command just define own BH1750_LOG command macro
+
+  Template for your custom format (replace square brackets by your own text):
+  #  define BH1750_LOG(fmt, ...) Serial.printf(                              \
+      "[your formatted prefix]" fmt "[your formatted suffix]",               \
+      [[your prefix arg_1], [your prefix arg_2], ..., [your prefix arg_n],]  \
+      ##__VA_ARGS__                                                          \
+      [, [your suffix arg_1], [your suffix arg_2], ..., [your suffix arg_n]] \
+      )
+
+  Default output example (without build in console timestamp):
+          24.358 sec. -> [BH1750] Error: Invalid mode
+        3920.563 sec. -> [BH1750] Raw value: 32568.50
+
+  Default output example (with build in console timestamp):
+  17:28:32.478 ->         24.358 sec. -> [BH1750] Error: Invalid mode
+  17:28:32.478 ->       3920.563 sec. -> [BH1750] Raw value: 32568.50
+*/
+#ifndef BH1750_LOG
+#  define BH1750_LOG(fmt, ...) Serial.printf(       \
+      "% 9.3f sec. -> [BH1750] " fmt "\n",          \
+      (double)millis() / 1000.0,                    \
+      ##__VA_ARGS__                                 \
+      )
+#endif // !BH1750_LOG
+
+// This error message shows when invalid measurement mode is selected
+// No additional formatting parameters (e.g. %d) allowed
+#ifndef BH1750_INVALID_MODE
+#    define BH1750_INVALID_MODE         "Error: Invalid mode"
+#endif // !BH1750_INVALID_MODE
+
+// This error message shows when buffer of the Wire bus has not insufficient space to send data
+// No additional formatting parameters (e.g. %d) allowed
+#ifndef BH1750_BUFFER_OVERFLOW
+#  define BH1750_BUFFER_OVERFLOW        "Error: Data are too long for transmit buffer"
+#endif // !BH1750_BUFFER_OVERFLOW
+
+// This error message shows when the Wire bus cannot reach the sensor 
+// (e.g. sensor is disconnected or was used wrong address)
+// No additional formatting parameters (e.g. %d) allowed
+#ifndef BH1750_ADDRESS_NACK
+#    define BH1750_ADDRESS_NACK         "Error: Received NACK on transmit of address"
+#endif // !BH1750_ADDRESS_NACK
+
+// This error message shows when the sensor receives invalid data/command or it's buffer overflows
+// No additional formatting parameters (e.g. %d) allowed
+#ifndef BH1750_DATA_NACK
+#  define BH1750_DATA_NACK              "Error: Received NACK on transmit of data"
+#endif // !BH1750_DATA_NACK
+
+// This error message shows when an other error of the Wire bus appears
+// No additional formatting parameters (e.g. %d) allowed
+#ifndef BH1750_OTHER_ERROR
+#  define BH1750_OTHER_ERROR            "Error: Other error of the bus"
+#endif // !BH1750_OTHER_ERROR
+
+// This error message shows when an undefined error of the Wire bus appears
+// No additional formatting parameters (e.g. %d) allowed
+#ifndef BH1750_UNDEFINED_ERROR
+#  define BH1750_UNDEFINED_ERROR        "Error: Undefined error of the bus"
+#endif // !BH1750_UNDEFINED_ERROR
+
+// This error message shows when entered measurement time is out of allowed range
+// No additional formatting parameters (e.g. %d) allowed
+#ifndef BH1750_MTREG_OUT_OF_RANGE
+#  define BH1750_MTREG_OUT_OF_RANGE     "Error: MTreg value is out of range"
+#endif // !BH1750_MTREG_OUT_OF_RANGE
+
+// This error message shows when the sensor has not been initialized yet
+// No additional formatting parameters (e.g. %d) allowed
+#ifndef BH1750_SENSOR_UNCONFIGURED
+#  define BH1750_SENSOR_UNCONFIGURED    "Error: Device is not configured"
+#endif // !BH1750_SENSOR_UNCONFIGURED
+
+// The format of sensor's raw value output shown when the debug of values is enabled
+// Formatting parameter "%f" must be present in the message
+#ifndef BH1750_RAW_VALUE_FORMAT
+#  define BH1750_RAW_VALUE_FORMAT       "Raw value: %f"
+#endif // !BH1750_RAW_VALUE_FORMAT
+
+// The format of sensor's MTreg factor shown when the debug of values is enabled
+// MTreg is defined as ratio of the default MTreg value and setted value
+// Formatting parameter "%f" must be present in the message
+#ifndef BH1750_MTREG_FACTOR_FORMAT
+#  define BH1750_MTREG_FACTOR_FORMAT    "Raw value: %f"
+#endif // !BH1750_MTREG_FACTOR_FORMAT
+
+// The format of sensor's MTreg factor shown when the debug of values is enabled
+// MTreg is defined as ratio of the default MTreg value and setted value
+// Formatting parameter "%f" must be present in the message
+#ifndef BH1750_CONVERTED_VALUE_FORMAT
+#  define BH1750_CONVERTED_VALUE_FORMAT "Converted value: %f"
+#endif // !BH1750_CONVERTED_VALUE_FORMAT
+
+#endif // !BH1750messages_h


### PR DESCRIPTION
Due to possibility that printing of error messages can stuck program flow it is better to add choice to enable or disable this messages according to needs of user/programmer of the library.

![obrazek](https://user-images.githubusercontent.com/78907070/154097476-b6cd49ec-065d-4f62-b10f-9f6553f8f431.png)
