### PR TITLE
`begin()` no longer overwrites previous address assignments by default

### DIFF
--- a/src/BH1750.cpp
+++ b/src/BH1750.cpp
@@ -43,9 +43,9 @@
 
 /**
  * Constructor
- * @params addr Sensor address (0x76 or 0x72, see datasheet)
+ * @params addr Sensor address (0x23 or 0x5C, see datasheet)
  *
- * On most sensor boards, it was 0x76
+ * On most sensor boards, it was 0x23
  */
 BH1750::BH1750(byte addr) {
 

--- a/src/BH1750.h
+++ b/src/BH1750.h
@@ -62,7 +62,7 @@ public:
   };
 
   BH1750(byte addr = 0x23);
-  bool begin(Mode mode = CONTINUOUS_HIGH_RES_MODE, byte addr = 0x23,
+  bool begin(Mode mode = CONTINUOUS_HIGH_RES_MODE, byte addr = 0x00,
              TwoWire* i2c = nullptr);
   bool configure(Mode mode);
   bool setMTreg(byte MTreg);


### PR DESCRIPTION
Currently, if the user specifies a custom address to the `BH1750` constructor, it will be overridden when the user calls the `begin()` function. I believe this was the root of the problem for #64. Two sensors were being used on the bus. The user was attempting to specify the override address in the constructor for the second sensor, but it was being overridden when calling `begin()`

example:
```cpp
BH1750 sensor(0x5C); // initialize sensor with 0x5C
sensor.begin(); // library overwrites 0x5C address with 0x23 default parameter
```
 
This PR fixes the behavior by redefining the default address in the `begin` call with `0x00`. This way the address is only overridden if the user supplies a non-zero address. The constructor already specifies a default 0x23 address, so it is guaranteed that the `BH1750_I2CADDR` will either have a value of `0x23` or the user-specified value by the time `begin()` is called